### PR TITLE
Fix commercial page filename and navigation links

### DIFF
--- a/Roofing_Solutions_UT_Website/about.html
+++ b/Roofing_Solutions_UT_Website/about.html
@@ -29,13 +29,13 @@
           </ul>
         </li>
         <li class="dropdown">
-          <a href="commersial.html">Commercial Roofing</a>
+          <a href="commercial.html">Commercial Roofing</a>
           <ul class="dropdown-content">
-            <li><a href="commersial.html#metal-roofs">Metal Roofs</a></li>
-            <li><a href="commersial.html#shingle-roofs">Shingle Roofs</a></li>
-            <li><a href="commersial.html#flat-roofs">Flat Roofs</a></li>
-            <li><a href="commersial.html#roof-replacement">Roof Replacement</a></li>
-            <li><a href="commersial.html#roofing-consultation">Roofing Consultation</a></li>
+            <li><a href="commercial.html#metal-roofs">Metal Roofs</a></li>
+            <li><a href="commercial.html#shingle-roofs">Shingle Roofs</a></li>
+            <li><a href="commercial.html#flat-roofs">Flat Roofs</a></li>
+            <li><a href="commercial.html#roof-replacement">Roof Replacement</a></li>
+            <li><a href="commercial.html#roofing-consultation">Roofing Consultation</a></li>
           </ul>
         </li>
         <li class="dropdown">

--- a/Roofing_Solutions_UT_Website/blog.html
+++ b/Roofing_Solutions_UT_Website/blog.html
@@ -29,13 +29,13 @@
         </ul>
       </li>
       <li class="dropdown">
-        <a href="commersial.html">Commercial Roofing</a>
+        <a href="commercial.html">Commercial Roofing</a>
         <ul class="dropdown-content">
-          <li><a href="commersial.html#metal-roofs">Metal Roofs</a></li>
-          <li><a href="commersial.html#shingle-roofs">Shingle Roofs</a></li>
-          <li><a href="commersial.html#flat-roofs">Flat Roofs</a></li>
-          <li><a href="commersial.html#roof-replacement">Roof Replacement</a></li>
-          <li><a href="commersial.html#roofing-consultation">Roofing Consultation</a></li>
+          <li><a href="commercial.html#metal-roofs">Metal Roofs</a></li>
+          <li><a href="commercial.html#shingle-roofs">Shingle Roofs</a></li>
+          <li><a href="commercial.html#flat-roofs">Flat Roofs</a></li>
+          <li><a href="commercial.html#roof-replacement">Roof Replacement</a></li>
+          <li><a href="commercial.html#roofing-consultation">Roofing Consultation</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/Roofing_Solutions_UT_Website/commercial.html
+++ b/Roofing_Solutions_UT_Website/commercial.html
@@ -29,13 +29,13 @@
           </ul>
         </li>
         <li class="dropdown">
-          <a href="commersial.html">Commercial Roofing</a>
+          <a href="commercial.html">Commercial Roofing</a>
           <ul class="dropdown-content">
-            <li><a href="commersial.html#metal-roofs">Metal Roofs</a></li>
-            <li><a href="commersial.html#shingle-roofs">Shingle Roofs</a></li>
-            <li><a href="commersial.html#flat-roofs">Flat Roofs</a></li>
-            <li><a href="commersial.html#roof-replacement">Roof Replacement</a></li>
-            <li><a href="commersial.html#roofing-consultation">Roofing Consultation</a></li>
+            <li><a href="commercial.html#metal-roofs">Metal Roofs</a></li>
+            <li><a href="commercial.html#shingle-roofs">Shingle Roofs</a></li>
+            <li><a href="commercial.html#flat-roofs">Flat Roofs</a></li>
+            <li><a href="commercial.html#roof-replacement">Roof Replacement</a></li>
+            <li><a href="commercial.html#roofing-consultation">Roofing Consultation</a></li>
           </ul>
         </li>
         <li class="dropdown">

--- a/Roofing_Solutions_UT_Website/index.html
+++ b/Roofing_Solutions_UT_Website/index.html
@@ -29,13 +29,13 @@
           </ul>
         </li>
         <li class="dropdown">
-          <a href="commersial.html">Commercial Roofing</a>
+          <a href="commercial.html">Commercial Roofing</a>
           <ul class="dropdown-content">
-            <li><a href="commersial.html#metal-roofs">Metal Roofs</a></li>
-            <li><a href="commersial.html#shingle-roofs">Shingle Roofs</a></li>
-            <li><a href="commersial.html#flat-roofs">Flat Roofs</a></li>
-            <li><a href="commersial.html#roof-replacement">Roof Replacement</a></li>
-            <li><a href="commersial.html#roofing-consultation">Roofing Consultation</a></li>
+            <li><a href="commercial.html#metal-roofs">Metal Roofs</a></li>
+            <li><a href="commercial.html#shingle-roofs">Shingle Roofs</a></li>
+            <li><a href="commercial.html#flat-roofs">Flat Roofs</a></li>
+            <li><a href="commercial.html#roof-replacement">Roof Replacement</a></li>
+            <li><a href="commercial.html#roofing-consultation">Roofing Consultation</a></li>
           </ul>
         </li>
         <li class="dropdown">

--- a/Roofing_Solutions_UT_Website/residential.html
+++ b/Roofing_Solutions_UT_Website/residential.html
@@ -29,13 +29,13 @@
           </ul>
         </li>
         <li class="dropdown">
-          <a href="commersial.html">Commercial Roofing</a>
+          <a href="commercial.html">Commercial Roofing</a>
           <ul class="dropdown-content">
-            <li><a href="commersial.html#metal-roofs">Metal Roofs</a></li>
-            <li><a href="commersial.html#shingle-roofs">Shingle Roofs</a></li>
-            <li><a href="commersial.html#flat-roofs">Flat Roofs</a></li>
-            <li><a href="commersial.html#roof-replacement">Roof Replacement</a></li>
-            <li><a href="commersial.html#roofing-consultation">Roofing Consultation</a></li>
+            <li><a href="commercial.html#metal-roofs">Metal Roofs</a></li>
+            <li><a href="commercial.html#shingle-roofs">Shingle Roofs</a></li>
+            <li><a href="commercial.html#flat-roofs">Flat Roofs</a></li>
+            <li><a href="commercial.html#roof-replacement">Roof Replacement</a></li>
+            <li><a href="commercial.html#roofing-consultation">Roofing Consultation</a></li>
           </ul>
         </li>
         <li class="dropdown">

--- a/Roofing_Solutions_UT_Website/snow.html
+++ b/Roofing_Solutions_UT_Website/snow.html
@@ -29,13 +29,13 @@
           </ul>
         </li>
         <li class="dropdown">
-          <a href="commersial.html">Commercial Roofing</a>
+          <a href="commercial.html">Commercial Roofing</a>
           <ul class="dropdown-content">
-            <li><a href="commersial.html#metal-roofs">Metal Roofs</a></li>
-            <li><a href="commersial.html#shingle-roofs">Shingle Roofs</a></li>
-            <li><a href="commersial.html#flat-roofs">Flat Roofs</a></li>
-            <li><a href="commersial.html#roof-replacement">Roof Replacement</a></li>
-            <li><a href="commersial.html#roofing-consultation">Roofing Consultation</a></li>
+            <li><a href="commercial.html#metal-roofs">Metal Roofs</a></li>
+            <li><a href="commercial.html#shingle-roofs">Shingle Roofs</a></li>
+            <li><a href="commercial.html#flat-roofs">Flat Roofs</a></li>
+            <li><a href="commercial.html#roof-replacement">Roof Replacement</a></li>
+            <li><a href="commercial.html#roofing-consultation">Roofing Consultation</a></li>
           </ul>
         </li>
         <li class="dropdown">


### PR DESCRIPTION
## Summary
- rename `commersial.html` to `commercial.html`
- update navigation menus to use the new filename

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684609eaf03883339f5d966a25ab3482