### PR TITLE
Fix anchor scroll offset

### DIFF
--- a/Roofing_Solutions_UT_Website/CSS/styles.css
+++ b/Roofing_Solutions_UT_Website/CSS/styles.css
@@ -22,6 +22,11 @@ body {
   background-color: var(--background);
 }
 
+/* Offset anchored sections for sticky header */
+section[id] {
+  scroll-margin-top: 160px;
+}
+
 /* Header */
 header {
   display: flex;


### PR DESCRIPTION
## Summary
- offset anchored sections so sticky header doesn't overlap

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6846103376d88333be7289f517c87f3c