### PR TITLE
Add quote button redirect

### DIFF
--- a/JS/scripts.js
+++ b/JS/scripts.js
@@ -41,6 +41,17 @@ fetch(projectsUrl)
   .then(data => console.log(data))
   .catch(error => console.error(error));
 
+// Redirect quote buttons to the Contact Us section
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.quote-btn').forEach(button => {
+    if (button.type !== 'submit') {
+      button.addEventListener('click', () => {
+        window.location.href = 'about.html#contact-us';
+      });
+    }
+  });
+});
+
 // Fetching Projects from Ghost API
 fetch('https://your-ghost-instance.com/api/v1/projects')
   .then(response => response.json())


### PR DESCRIPTION
## Summary
- redirect all `.quote-btn` buttons to the contact section of the About page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686320884c1083338c61cfa8f6b806d1